### PR TITLE
[FIX] FE dev API 연동 및 결제/관리자 보호 흐름 보강

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+VITE_APP_API_URL=https://api.seeatheater.store
+VITE_APP_KAKAO_JS_KEY=<kakao-js-key>
+VITE_KAKAO_CLIENT_ID=<kakao-client-id>
+VITE_KAKAO_REDIRECT_URI=<kakao-redirect-uri>

--- a/src/components/TheaterCard.jsx
+++ b/src/components/TheaterCard.jsx
@@ -3,18 +3,14 @@ import { useState } from 'react';
 import HeartFull from '@/assets/icons/heart-full.svg?react';
 import HeartEmpty from '@/assets/icons/HeartEmpty.svg?react';
 
-import axios from 'axios';
+import useAxios from '@/utils/hooks/useAxios';
 function TheaterCard({ data }) {
 	const [liked, setLiked] = useState(true);
+	const axiosClient = useAxios();
 	const handleClick = async (performerId) => {
 		try {
-			const response = await axios.delete(
-				`https://api.seeatheater.site/member-like/like/${performerId}`,
-				{
-					headers: {
-						Authorization: `Bearer ${import.meta.env.VITE_REACT_APP_ACCESS_TOKEN}`,
-					},
-				},
+			const response = await axiosClient.delete(
+				`/member-like/like/${performerId}`,
 			);
 
 			if (response.data.isSuccess) {

--- a/src/pages/TEST/TestUploadPic.jsx
+++ b/src/pages/TEST/TestUploadPic.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import axios from 'axios';
+import useAxios from '@/utils/hooks/useAxios';
 
 function TestUploadPic() {
 	const [extension, setExtension] = useState('jpg');
@@ -11,6 +12,7 @@ function TestUploadPic() {
 	const [uploadSuccess, setUploadSuccess] = useState(false);
 	const [showId, setShowId] = useState(1); // 테스트용 amateurShowId
 	const [content, setContent] = useState('테스트 내용');
+	const axiosClient = useAxios();
 
 	const handleRequest = async () => {
 		setLoading(true);
@@ -19,18 +21,12 @@ function TestUploadPic() {
 		setUploadSuccess(false);
 
 		try {
-			const res = await axios.get(
-				'https://api.seeatheater.site/upload/s3/presignedUrl',
-				{
-					params: {
-						imageExtension: extension,
-						filePath: filePath,
-					},
-					headers: {
-						Authorization: `Bearer ${import.meta.env.VITE_REACT_APP_ACCESS_TOKEN}`,
-					},
+			const res = await axiosClient.get('/upload/s3/presignedUrl', {
+				params: {
+					imageExtension: extension,
+					filePath: filePath,
 				},
-			);
+			});
 			setResponseUrl(res.data);
 		} catch (err) {
 			console.error(err);
@@ -90,15 +86,7 @@ function TestUploadPic() {
 		};
 
 		try {
-			await axios.post(
-				'https://api.seeatheater.site/amateurs/images',
-				payload,
-				{
-					headers: {
-						Authorization: `Bearer ${import.meta.env.VITE_REACT_APP_ACCESS_TOKEN}`,
-					},
-				},
-			);
+			await axiosClient.post('/amateurs/images', payload);
 			alert('✅ 이미지 업로드 및 등록 성공');
 		} catch (err) {
 			console.error(err);

--- a/src/pages/admin/register-request/RegisterRequestDetail.jsx
+++ b/src/pages/admin/register-request/RegisterRequestDetail.jsx
@@ -28,6 +28,7 @@ function RegisterRequestDetail() {
 		error,
 		doFetch, // PATCH/POST 등을 위해 추가했다고 가정
 	} = useCustomFetch(`/admin/amateurShow/${registerId}`);
+	const { fetchData } = useCustomFetch();
 
 	const data = fullData?.result || null;
 
@@ -42,24 +43,19 @@ function RegisterRequestDetail() {
 	const handleSave = async () => {
 		if (!registerId) return;
 
-		const accessToken = localStorage.getItem('accessToken');
-
 		const url =
 			selectedStatus === 'YES'
-				? `https://api.seeatheater.site/admin/approval/${registerId}/approve`
-				: `https://api.seeatheater.site/admin/approval/${registerId}/reject`;
+				? `/admin/approval/${registerId}/approve`
+				: `/admin/approval/${registerId}/reject`;
 
 		try {
-			const res = await fetch(url, {
-				method: 'PATCH',
-			});
+			const res = await fetchData(url, 'PATCH');
 
-			if (!res.ok) {
-				throw new Error(`서버 오류: ${res.status}`);
+			if (!res?.data?.isSuccess) {
+				throw new Error(`서버 오류: ${res?.status || 'unknown'}`);
 			}
 
-			const result = await res.json();
-			console.log('저장 성공', result);
+			console.log('저장 성공', res.data);
 
 			alert('저장되었습니다.');
 			setEditMode(false);

--- a/src/pages/register/RegisterStep4.jsx
+++ b/src/pages/register/RegisterStep4.jsx
@@ -1,31 +1,16 @@
 import styled from 'styled-components';
 import { RegisterWrapper } from './Register.style.js';
 import { useOutletContext } from 'react-router-dom';
+import useAxios from '@/utils/hooks/useAxios';
 function RegisterStep4() {
 	const { nextStep, formData, _setFormData } = useOutletContext();
-	const accessToken = localStorage.getItem('accessToken');
+	const axiosClient = useAxios();
 	const handleEnroll = async (e) => {
 		e.preventDefault(); // 폼 제출 기본 동작 막기
 		console.log('폼데이터', formData);
 
 		try {
-			const response = await fetch(
-				'https://api.seeatheater.site/amateurs/enroll',
-				{
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-						Authorization: `Bearer ${accessToken}`,
-					},
-					body: JSON.stringify(formData),
-				},
-			);
-
-			if (!response.ok) {
-				throw new Error(`등록 실패: ${response.status}`);
-			}
-
-			const data = await response.json();
+			const { data } = await axiosClient.post('/amateurs/enroll', formData);
 			console.log('등록 성공:', data);
 
 			alert('공연 등록이 완료되었습니다.');

--- a/src/pages/ticketingpage/hooks/useTicketing.jsx
+++ b/src/pages/ticketingpage/hooks/useTicketing.jsx
@@ -20,6 +20,7 @@ const useTicketing = (amateurShowId) => {
   // fetchData가 매번 새로 생성되는 것을 방지
   const fetchDataRef = useRef(fetchData);
   fetchDataRef.current = fetchData;
+  const paymentRequestInFlightRef = useRef(false);
 
   // 공연 정보
   const [eventInfo, setEventInfo] = useState({
@@ -261,11 +262,14 @@ const useTicketing = (amateurShowId) => {
 
   // 티켓 예매 실행
   const reserveTicket = async () => {
+    if (paymentRequestInFlightRef.current) return;
+
     if (!selectedRound || !selectedTicket || !people) {
       setError('필수 정보가 누락되었습니다.');
       return;
     }
 
+    paymentRequestInFlightRef.current = true;
     setLoading(true);
     try {
       // 1단계: 먼저 티켓을 예매하여 memberTicketId를 받아옴
@@ -318,6 +322,7 @@ const useTicketing = (amateurShowId) => {
       }
 
     } catch (err) {
+      paymentRequestInFlightRef.current = false;
       setError('예매 처리 중 오류가 발생했습니다.');
       console.error('Error reserving ticket:', err);
       setLoading(false);

--- a/src/pages/ticketingpage/pages/Step2.jsx
+++ b/src/pages/ticketingpage/pages/Step2.jsx
@@ -135,6 +135,8 @@ const Step2 = ({
 
 	// 다음 버튼 클릭 핸들러
 	const handleNextStep = async () => {
+		if (loading) return;
+
 		if (currentContent === 'payment' || currentContent === 'options') {
 			try {
 				await reserveTicket();
@@ -333,7 +335,7 @@ const Step2 = ({
 				</SummarySection>
 			</PcLayout>
 			{!isPC && (
-				<ActionButton isActive={nextActive} onClick={handleNextStep}>
+				<ActionButton isActive={nextActive && !loading} onClick={handleNextStep}>
 					{currentContent === 'options' ? '예매하기' : '다음'}
 				</ActionButton>
 			)}
@@ -347,7 +349,7 @@ const Step2 = ({
 						gap: '20px',
 					}}
 				>
-					<ActionButton isActive={nextActive} onClick={handleNextStep}>
+					<ActionButton isActive={nextActive && !loading} onClick={handleNextStep}>
 						{currentContent === 'payment' ? '예매하기' : '다음'}
 					</ActionButton>
 					<BackButton onClick={goToPreviousStep}>이전</BackButton>

--- a/src/routes/AdminProtectedRoute.jsx
+++ b/src/routes/AdminProtectedRoute.jsx
@@ -3,8 +3,9 @@ import { Navigate, Outlet } from 'react-router-dom';
 
 const AdminProtectedRoute = () => {
 	const { isLoggedIn } = useAuth();
+	const selectedRole = sessionStorage.getItem('selectedRole');
 
-	if (!isLoggedIn) {
+	if (!isLoggedIn || selectedRole !== 'ADMIN') {
 		alert('관리자 로그인이 필요합니다.');
 		return <Navigate to="/admin/login" replace />;
 	}


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - Part of #162(https://github.com/SeeATheater/CC_Backend/issues/162)

2. **📝 작업 내용**
    - 새 dev/staging 백엔드 `https://api.seeatheater.store` 기준으로 FE API 호출이 섞이지 않도록 하드코딩된 기존 API URL을 제거했습니다.
    - 기존 `https://api.seeatheater.site` 직접 호출을 상대 경로 + 공통 `useAxios` / `useCustomFetch` 흐름으로 정리했습니다.
    - `VITE_REACT_APP_ACCESS_TOKEN` 기반 Authorization 사용을 제거하고, 기존 localStorage accessToken + axios interceptor 흐름을 사용하도록 맞췄습니다.
    - KakaoPay ready 요청이 빠른 연타로 중복 호출되지 않도록 `paymentRequestInFlightRef`와 loading 기반 버튼 비활성화를 보강했습니다.
    - 관리자 라우트 보호에서 기존 `isLoggedIn` 확인에 더해 `sessionStorage.selectedRole === 'ADMIN'` 최소 체크를 추가했습니다.
    - `.env.example`에 dev/staging 연동용 placeholder를 추가했습니다.

    **제거한 hardcoded URL**
    - `https://api.seeatheater.site/amateurs/enroll`
    - `https://api.seeatheater.site/admin/approval/:id/approve`
    - `https://api.seeatheater.site/admin/approval/:id/reject`
    - `https://api.seeatheater.site/member-like/like/:performerId`
    - `https://api.seeatheater.site/upload/s3/presignedUrl`
    - `https://api.seeatheater.site/amateurs/images`

4. **💬 리뷰 요구사항**
    - 하드코딩 API URL을 상대 경로 + 공통 axios 흐름으로 정리한 방식이 현재 FE 구조와 맞는지 확인 부탁드립니다.
    - KakaoPay ready 중복 클릭 방지 방식이 현재 결제 UX와 충돌하지 않는지 검토 부탁드립니다.
    - 관리자 라우트에서 `selectedRole === 'ADMIN'`을 최소 체크로 추가한 방식이 현재 로그인/세션 저장 방식과 맞는지 확인 부탁드립니다.