### PR TITLE
[FIX] 주요 FE 서비스 라우트 로그인 보호 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Logout from './pages/logout/Logout';
 import Withdrawal from './pages/withdrawal/Withdrawal';
 
 import SmallTheaterRoutes from './routes/SmallTheaterRoutes.jsx';
+import ProtectedRoute from './routes/ProtectedRoute.jsx';
 
 import Home from './pages/home/Home';
 import TicketingPage from './pages/ticketingpage/TicketingPage.jsx';
@@ -35,41 +36,42 @@ function App() {
 			<Route path="/login" element={<Onboarding />} />
 			<Route path="/login/auth" element={<Login />} />
 			<Route path="/auth/kakao/callback" element={<KakaoCallback />} />
-			<Route path="/logout" element={<Logout />} />
-			<Route path="/withdrawal" element={<Withdrawal />} />
-
-			<Route path="/" element={<Home />} />
-			<Route path="/menu" element={<FullScreenMenu />} />
-
-			<Route path="/small-theater/*" element={<SmallTheaterRoutes />} />
-
-			<Route path="/search" element={<SearchMobile />} />
-			<Route path="/ticketing/:playId" element={<TicketingPage />} />
 			{/*<Route path="/kakaoPay/approve" element={<KakaoPayApprove />} />*/}
-			<Route path="/board/*" element={<Board />} />
-			<Route path="/gallery" element={<Gallery />} />
-			<Route path="/info" element={<Info />} />
-
-			<Route path="/plays" element={<Playlist />} />
-			<Route path="/plays/detail/:playId" element={<Detail />} />
-
-			<Route path="/notification" element={<Notification />} />
-			<Route path="/production/:prodId" element={<Production />} />
-			<Route
-				path="/production/album/:prodId/:AlbumId"
-				element={<ProdDetail />}
-			/>
-			<Route path="/production/upload_photo" element={<UploadPic />} />
-			<Route path="/production/uploadDone" element={<UploadDone />} />
-
-			<Route path="/mypage/*" element={<MyPageRoutes />} />
-
 			<Route path="/admin/*" element={<AdminRoutes />} />
+			<Route path="/service" element={<ServiceTerms />} />
+
+			<Route element={<ProtectedRoute />}>
+				<Route path="/logout" element={<Logout />} />
+				<Route path="/withdrawal" element={<Withdrawal />} />
+
+				<Route path="/" element={<Home />} />
+				<Route path="/menu" element={<FullScreenMenu />} />
+
+				<Route path="/small-theater/*" element={<SmallTheaterRoutes />} />
+
+				<Route path="/search" element={<SearchMobile />} />
+				<Route path="/ticketing/:playId" element={<TicketingPage />} />
+				<Route path="/board/*" element={<Board />} />
+				<Route path="/gallery" element={<Gallery />} />
+				<Route path="/info" element={<Info />} />
+
+				<Route path="/plays" element={<Playlist />} />
+				<Route path="/plays/detail/:playId" element={<Detail />} />
+
+				<Route path="/notification" element={<Notification />} />
+				<Route path="/production/:prodId" element={<Production />} />
+				<Route
+					path="/production/album/:prodId/:AlbumId"
+					element={<ProdDetail />}
+				/>
+				<Route path="/production/upload_photo" element={<UploadPic />} />
+				<Route path="/production/uploadDone" element={<UploadDone />} />
+
+				<Route path="/mypage/*" element={<MyPageRoutes />} />
+				<Route path="test/upload-pic" element={<TestUploadPic />} />
+			</Route>
 
 			<Route path="*" element={<NotFoundPage />} />
-
-			<Route path="test/upload-pic" element={<TestUploadPic />} />
-			<Route path="/service" element={<ServiceTerms />} />
 		</Routes>
 	);
 }

--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -6,18 +6,25 @@ import chevron from '@/assets/icons/chevronLeft.svg?react';
 import { useIsMobile } from '@/utils/hooks/useIsMobile';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useEffect } from 'react';
+import { useAuth } from '@/context/AuthContext';
 
 function Login() {
 	const isMobile = useIsMobile();
 	const navigate = useNavigate();
 	const [searchParams] = useSearchParams();
+	const { isLoggedIn } = useAuth();
 
 	useEffect(() => {
+		if (isLoggedIn) {
+			navigate('/', { replace: true });
+			return;
+		}
+
 		const role = searchParams.get('role');
 		if (role) {
 			sessionStorage.setItem('selectedRole', role);
 		}
-	}, [searchParams]);
+	}, [isLoggedIn, navigate, searchParams]);
 
 	return (
 		<Container>

--- a/src/pages/login/Onboarding.jsx
+++ b/src/pages/login/Onboarding.jsx
@@ -3,10 +3,19 @@ import { useNavigate } from 'react-router-dom';
 import LogoWeb from '@/assets/icons/login/LogoWeb.svg?react';
 import LogoMobile from '@/assets/icons/login/LogoMobile.svg?react';
 import { useIsMobile } from '@/utils/hooks/useIsMobile';
+import { useEffect } from 'react';
+import { useAuth } from '@/context/AuthContext';
 
 function Onboarding() {
 	const isMobile = useIsMobile();
 	const navigate = useNavigate();
+	const { isLoggedIn } = useAuth();
+
+	useEffect(() => {
+		if (isLoggedIn) {
+			navigate('/', { replace: true });
+		}
+	}, [isLoggedIn, navigate]);
 
 	const handleLoginClick = (roleType) => {
 		navigate(`/login/auth?role=${roleType}`);

--- a/src/routes/ProtectedRoute.jsx
+++ b/src/routes/ProtectedRoute.jsx
@@ -1,0 +1,27 @@
+import { useAuth } from '@/context/AuthContext';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+
+const PAYMENT_RESULT_STATUSES = ['success', 'fail', 'cancel'];
+
+const ProtectedRoute = () => {
+	const { isLoggedIn } = useAuth();
+	const location = useLocation();
+	const accessToken = localStorage.getItem('accessToken');
+	const refreshToken = localStorage.getItem('refreshToken');
+	const paymentStatus = new URLSearchParams(location.search).get('payment');
+	const isPaymentResultRoute =
+		location.pathname.startsWith('/ticketing/') &&
+		PAYMENT_RESULT_STATUSES.includes(paymentStatus);
+
+	if (isPaymentResultRoute) {
+		return <Outlet />;
+	}
+
+	if (!isLoggedIn && (!accessToken || !refreshToken)) {
+		return <Navigate to="/login" replace state={{ from: location }} />;
+	}
+
+	return <Outlet />;
+};
+
+export default ProtectedRoute;


### PR DESCRIPTION
#⃣ 연관된 이슈

- Part of #162(https://github.com/SeeATheater/CC_Backend/issues/162)

📝 작업 내용

주요 FE 서비스 라우트에 로그인 보호 정책을 추가했습니다.

- 비로그인 사용자가 홈/공연/게시판/사진첩/마이페이지 등 주요 서비스 화면에 접근하면 `/login`으로 redirect되도록 `ProtectedRoute`를 추가했습니다.
- 로그인 사용자가 `/login`, `/login/auth`에 접근하면 `/`로 redirect되도록 처리했습니다.
- OAuth callback, admin login, 약관/서비스 페이지, 404 등 인증 흐름에 필요한 route는 public으로 유지했습니다.
- `/admin/*`는 route level에서는 public으로 유지하되, 실제 admin 하위 페이지는 기존 `AdminProtectedRoute`에서 `isLoggedIn + sessionStorage.selectedRole === 'ADMIN'` 기준으로 보호합니다.
- `/ticketing/:playId?payment=success|fail|cancel` 형태의 결제 복귀 흐름은 `ProtectedRoute`에 막히지 않도록 예외 처리했습니다.
- `/kakaoPay/approve` route는 기존 주석 상태를 유지했습니다.

Public Routes

- `/login`
- `/login/auth`
- `/auth/kakao/callback`
- `/admin/*`
- `/service`
- `*` 404

Protected Routes

- `/`
- `/logout`
- `/withdrawal`
- `/menu`
- `/small-theater/*`
- `/search`
- `/ticketing/:playId`
- `/board/*`
- `/gallery`
- `/info`
- `/plays`
- `/plays/detail/:playId`
- `/notification`
- `/production/:prodId`
- `/production/album/:prodId/:AlbumId`
- `/production/upload_photo`
- `/production/uploadDone`
- `/mypage/*`
- `/test/upload-pic`

💬 리뷰 요구사항

- `/admin/*`를 route level에서는 public으로 두고, 실제 admin 하위 페이지는 기존 `AdminProtectedRoute`에서 보호하는 방식이 현재 구조와 맞는지 확인 부탁드립니다.
- OAuth callback 및 payment query flow가 `ProtectedRoute`에 막히지 않도록 둔 예외 처리가 적절한지 검토 부탁드립니다.
- 로그인 판단 기준으로 `useAuth().isLoggedIn`과 localStorage token을 함께 보는 방식이 현재 auth state 복원 흐름과 맞는지 확인 부탁드립니다.

✅ 검증

- `npm run build` 통과
  - `%VITE_APP_KAKAO_JS_KEY%` env 미정의 경고 및 chunk size 경고는 기존 env/build-size 관련 경고로, 이번 변경과 직접 관련 없습니다.
- `git diff --check` 통과
- 변경 파일 대상 lint 통과
- `rg "ProtectedRoute|AdminProtectedRoute|isLoggedIn|accessToken|selectedRole" src` 확인 완료
- `rg "seeatheater.site|VITE_REACT_APP_ACCESS_TOKEN" src .env.example README.md` 결과 없음

⚠️ 참고

- `npm run lint` 전체 실행은 실패했습니다.
- 실패 원인은 repo 기존 lint 문제 178건이며, 대부분 unused vars, hook dependency, import path, 기존 `MyTickets.jsx` undefined 변수 등입니다.
- 이번 변경 파일인 `App.jsx`, `Login.jsx`, `Onboarding.jsx`, `ProtectedRoute.jsx`, `AdminProtectedRoute.jsx` 대상 lint는 통과했습니다.
- `VITE_REACT_APP_BASIC_URL`은 `TicketDetail.jsx`에 기존 1건 남아 있으나, 이번 라우팅 보호 범위 밖이라 수정하지 않았습니다.

🧪 수동 QA 체크리스트

- 비로그인 `/` 접근 → `/login` 이동
- 비로그인 `/plays`, `/board`, `/gallery`, `/mypage` 직접 접근 → `/login` 이동
- 비로그인 `/login`, `/login/auth`, `/auth/kakao/callback` 접근 가능
- 로그인 상태에서 `/login`, `/login/auth` 접근 → `/` 이동
- `/ticketing/:playId?payment=success|fail|cancel` 비로그인 접근이 막히지 않는지 확인
- `/admin/login` 접근 가능
- 비관리자 또는 비로그인 `/admin/dashboard` 접근 → `/admin/login` 이동
- ADMIN 로그인 후 admin 하위 페이지 접근 가능