### PR TITLE
[FIX] 만료된 세션 처리 안정화

### DIFF
--- a/src/components/Notification/NotiComponent.jsx
+++ b/src/components/Notification/NotiComponent.jsx
@@ -17,10 +17,13 @@ function NotiComponent() {
 
 	const isRequesting = useRef(false);
 	const observerRef = useRef(null);
+	const observerInstanceRef = useRef(null);
+	const authenticationFailed = useRef(false);
+	const initialFetchStarted = useRef(false);
 	const { fetchData } = useCustomFetch();
 
 	const fetchNoti = useCallback(async () => {
-		if (isRequesting.current || !hasNext) return;
+		if (isRequesting.current || authenticationFailed.current || !hasNext) return;
 
 		isRequesting.current = true;
 		setIsFetching(true);
@@ -32,6 +35,15 @@ function NotiComponent() {
 
 		try {
 			const res = await fetchData(url, 'GET');
+			const status = res?.error?.response?.status;
+
+			if (status === 401 || status === 403) {
+				authenticationFailed.current = true;
+				setHasNext(false);
+				observerInstanceRef.current?.disconnect();
+				return;
+			}
+
 			const result = res?.data?.result;
 
 			if (result) {
@@ -46,11 +58,13 @@ function NotiComponent() {
 			isRequesting.current = false;
 			setIsFetching(false);
 		}
-	}, [cursorId, hasNext, isFetching, fetchData]);
+	}, [cursorCreated, cursorId, fetchData, hasNext]);
 
 	useEffect(() => {
+		if (initialFetchStarted.current) return;
+		initialFetchStarted.current = true;
 		fetchNoti();
-	}, []);
+	}, [fetchNoti]);
 
 	useEffect(() => {
 		const observer = new IntersectionObserver(
@@ -61,12 +75,18 @@ function NotiComponent() {
 			},
 			{ rootMargin: '100px', threshold: 0 },
 		);
+		observerInstanceRef.current = observer;
 
 		if (observerRef.current) {
 			observer.observe(observerRef.current);
 		}
 
-		return () => observer.disconnect();
+		return () => {
+			observer.disconnect();
+			if (observerInstanceRef.current === observer) {
+				observerInstanceRef.current = null;
+			}
+		};
 	}, [fetchNoti, hasNext, isFetching]);
 
 	const filteredNotices = notices.filter((noti) => {
@@ -75,8 +95,6 @@ function NotiComponent() {
 		if (selectedOption === '소극장 공연') return noti.noticeType !== 'AD';
 		return true;
 	});
-
-	console.log(notices);
 
 	return (
 		<Box>

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,6 +1,11 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 import { axiosInstance } from '@/utils/apis/axiosInstance';
 import { useNavigate } from 'react-router-dom';
+import {
+	AUTH_LOGOUT_EVENT,
+	clearStoredAuth,
+	isAccessTokenValid,
+} from '@/utils/apis/axiosInstance';
 
 const AuthContext = createContext();
 
@@ -15,18 +20,33 @@ export const AuthProvider = ({ children }) => {
 		const accessToken = localStorage.getItem('accessToken');
 		const refreshToken = localStorage.getItem('refreshToken');
 
-		if (accessToken && refreshToken) {
+		if (isAccessTokenValid(accessToken) && refreshToken) {
 			setAccessToken(accessToken);
 			setRefreshToken(refreshToken);
 			setIsLoggedIn(true);
 			axiosInstance.defaults.headers.common['Authorization'] =
 				`Bearer ${accessToken}`;
 		} else {
+			localStorage.removeItem('accessToken');
+			localStorage.removeItem('refreshToken');
+			sessionStorage.removeItem('selectedRole');
 			setIsLoggedIn(false);
 			setAccessToken(null);
 			setRefreshToken(null);
 			delete axiosInstance.defaults.headers.common['Authorization'];
 		}
+	}, []);
+
+	useEffect(() => {
+		const resetAuthState = () => {
+			setAccessToken(null);
+			setRefreshToken(null);
+			setIsLoggedIn(false);
+			delete axiosInstance.defaults.headers.common.Authorization;
+		};
+
+		window.addEventListener(AUTH_LOGOUT_EVENT, resetAuthState);
+		return () => window.removeEventListener(AUTH_LOGOUT_EVENT, resetAuthState);
 	}, []);
 
 	const setAuthInfo = (accessToken, refreshToken, path) => {
@@ -42,9 +62,7 @@ export const AuthProvider = ({ children }) => {
 	};
 
 	const logout = (path) => {
-		localStorage.removeItem('accessToken');
-		localStorage.removeItem('refreshToken');
-		sessionStorage.removeItem('selectedRole');
+		clearStoredAuth();
 		setAccessToken(null);
 		setRefreshToken(null);
 		setIsLoggedIn(false);

--- a/src/pages/logout/Logout.jsx
+++ b/src/pages/logout/Logout.jsx
@@ -1,6 +1,28 @@
+import { useEffect, useRef } from 'react';
+import { useAuth } from '@/context/AuthContext';
+import useCustomFetch from '@/utils/hooks/useCustomFetch';
+
 function Logout() {
-  return (
-    <></>
-  )
+	const { logout } = useAuth();
+	const { fetchData } = useCustomFetch();
+	const requested = useRef(false);
+
+	useEffect(() => {
+		if (requested.current) return;
+		requested.current = true;
+
+		const requestLogout = async () => {
+			try {
+				await fetchData('/auth/logout', 'POST', {});
+			} finally {
+				logout('/login');
+			}
+		};
+
+		requestLogout();
+	}, [fetchData, logout]);
+
+	return null;
 }
+
 export default Logout;

--- a/src/pages/mypage/MyPageMenu.jsx
+++ b/src/pages/mypage/MyPageMenu.jsx
@@ -25,11 +25,11 @@ function MyPageMenu() {
 	const handleLogout = async () => {
 		const res = await fetchData('/auth/logout', 'POST', {});
 
-		if (res?.status === 200) {
-			logout('/');
-		} else {
+		if (res?.status !== 200) {
 			console.error('로그아웃 실패:', res);
 		}
+
+		logout('/login');
 	};
 	const handleDeactivate = async () => {
 		const res = await fetchData('/member/myPage/deActive', 'PATCH', {});

--- a/src/routes/ProtectedRoute.jsx
+++ b/src/routes/ProtectedRoute.jsx
@@ -1,5 +1,6 @@
 import { useAuth } from '@/context/AuthContext';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { isAccessTokenValid } from '@/utils/apis/axiosInstance';
 
 const PAYMENT_RESULT_STATUSES = ['success', 'fail', 'cancel'];
 
@@ -8,6 +9,7 @@ const ProtectedRoute = () => {
 	const location = useLocation();
 	const accessToken = localStorage.getItem('accessToken');
 	const refreshToken = localStorage.getItem('refreshToken');
+	const hasValidAccessToken = isAccessTokenValid(accessToken);
 	const paymentStatus = new URLSearchParams(location.search).get('payment');
 	const isPaymentResultRoute =
 		location.pathname.startsWith('/ticketing/') &&
@@ -17,7 +19,7 @@ const ProtectedRoute = () => {
 		return <Outlet />;
 	}
 
-	if (!isLoggedIn && (!accessToken || !refreshToken)) {
+	if (!hasValidAccessToken || (!isLoggedIn && !refreshToken)) {
 		return <Navigate to="/login" replace state={{ from: location }} />;
 	}
 

--- a/src/utils/apis/axiosInstance.js
+++ b/src/utils/apis/axiosInstance.js
@@ -1,5 +1,42 @@
 import axios from 'axios';
 
+const AUTH_LOGOUT_EVENT = 'auth:logout';
+
+const decodeJwtPayload = (token) => {
+	const payload = token.split('.')[1];
+	if (!payload) return null;
+
+	const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+	const decoded = decodeURIComponent(
+		atob(normalized)
+			.split('')
+			.map((char) => `%${char.charCodeAt(0).toString(16).padStart(2, '0')}`)
+			.join(''),
+	);
+
+	return JSON.parse(decoded);
+};
+
+const isAccessTokenValid = (token) => {
+	if (!token) return false;
+
+	try {
+		const payload = decodeJwtPayload(token);
+		if (!payload?.exp) return false;
+
+		return payload.exp * 1000 > Date.now();
+	} catch {
+		return false;
+	}
+};
+
+const clearStoredAuth = () => {
+	localStorage.removeItem('accessToken');
+	localStorage.removeItem('refreshToken');
+	sessionStorage.removeItem('selectedRole');
+	window.dispatchEvent(new Event(AUTH_LOGOUT_EVENT));
+};
+
 const axiosInstance = axios.create({
 	baseURL: import.meta.env.VITE_APP_API_URL,
 	headers: {
@@ -8,4 +45,9 @@ const axiosInstance = axios.create({
 	},
 });
 
-export { axiosInstance };
+export {
+	AUTH_LOGOUT_EVENT,
+	axiosInstance,
+	clearStoredAuth,
+	isAccessTokenValid,
+};

--- a/src/utils/hooks/useAxios.js
+++ b/src/utils/hooks/useAxios.js
@@ -1,6 +1,47 @@
 import { useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { axiosInstance } from '@/utils/apis/axiosInstance';
+import axios from 'axios';
+import {
+	axiosInstance,
+	clearStoredAuth,
+} from '@/utils/apis/axiosInstance';
+
+let refreshPromise = null;
+
+const refreshAccessToken = () => {
+	if (!refreshPromise) {
+		const refreshToken = localStorage.getItem('refreshToken');
+
+		if (!refreshToken) {
+			return Promise.reject(new Error('Refresh token is missing.'));
+		}
+
+		refreshPromise = axios
+			.post(
+				`${import.meta.env.VITE_APP_API_URL}/auth/refresh`,
+				{ refreshToken },
+				{ withCredentials: true },
+			)
+			.then((response) => {
+				const newAccessToken =
+					response.data?.accessToken ?? response.data?.result?.accessToken;
+
+				if (!newAccessToken) {
+					throw new Error('Refresh response did not include an access token.');
+				}
+
+				localStorage.setItem('accessToken', newAccessToken);
+				axiosInstance.defaults.headers.common.Authorization =
+					`Bearer ${newAccessToken}`;
+				return newAccessToken;
+			})
+			.finally(() => {
+				refreshPromise = null;
+			});
+	}
+
+	return refreshPromise;
+};
 
 const useAxios = () => {
 	const navigate = useNavigate();
@@ -17,22 +58,20 @@ const useAxios = () => {
 		async (error) => {
 			const originalRequest = error.config;
 
-			// accessToken 만료 시
-			if (error.response?.status === 401 && !originalRequest._retry) {
+			if (
+				error.response?.status === 401 &&
+				originalRequest &&
+				!originalRequest._retry
+			) {
 				originalRequest._retry = true;
-				const refreshToken = localStorage.getItem('refreshToken');
-
-				if (!refreshToken) {
-					console.error('refreshToken 없음 → 로그인 페이지로 이동');
-					navigate('/login', { replace: true });
-					return Promise.reject(error);
-				}
 
 				try {
-					originalRequest.headers.Authorization = `Bearer ${refreshToken}`;
+					const newAccessToken = await refreshAccessToken();
+					originalRequest.headers = originalRequest.headers ?? {};
+					originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
 					return axiosInstance(originalRequest);
 				} catch (refreshError) {
-					console.error('refreshToken도 만료 → 로그인 페이지로 이동');
+					clearStoredAuth();
 					navigate('/login', { replace: true });
 					return Promise.reject(refreshError);
 				}

--- a/src/utils/hooks/useCustomFetch.js
+++ b/src/utils/hooks/useCustomFetch.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import useAxios from './useAxios';
 
 const useCustomFetch = (url, method = 'GET', body = null) => {
@@ -8,36 +8,39 @@ const useCustomFetch = (url, method = 'GET', body = null) => {
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState(false);
 
-	const fetchData = async (
-		customUrl = url,
-		customMethod = method,
-		customBody = body,
-	) => {
-		if (!customUrl) return;
-		setLoading(true);
-		setError(false);
+	const fetchData = useCallback(
+		async (
+			customUrl = url,
+			customMethod = method,
+			customBody = body,
+		) => {
+			if (!customUrl) return;
+			setLoading(true);
+			setError(false);
 
-		try {
-			const response = await axiosClient({
-				method: customMethod,
-				url: customUrl,
-				data: customBody,
-			});
-			setData(response.data);
-			return response;
-		} catch (err) {
-			setError(true);
-			return { isSuccess: false, message: 'API 요청 실패', error: err };
-		} finally {
-			setLoading(false);
-		}
-	};
+			try {
+				const response = await axiosClient({
+					method: customMethod,
+					url: customUrl,
+					data: customBody,
+				});
+				setData(response.data);
+				return response;
+			} catch (err) {
+				setError(true);
+				return { isSuccess: false, message: 'API 요청 실패', error: err };
+			} finally {
+				setLoading(false);
+			}
+		},
+		[axiosClient, body, method, url],
+	);
 
 	useEffect(() => {
 		if (url && method === 'GET') {
 			fetchData();
 		}
-	}, [url, method]);
+	}, [fetchData, method, url]);
 
 	return { data, loading, error, fetchData };
 };


### PR DESCRIPTION
#⃣ 연관된 이슈

Part of #162(https://github.com/SeeATheater/CC_Backend/issues/162)

📝 작업 내용

FE dev/staging 연동 과정에서 만료된 인증 세션 처리와 401/403 응답 처리 흐름을 안정화했습니다.

* JWT exp 기준으로 만료된 access token을 사전에 차단하도록 수정했습니다.
* 기존에 refresh token을 원 요청의 Authorization Bearer로 재사용하던 흐름을 제거했습니다.
* /auth/refresh 요청은 single-flight 방식으로 처리해 중복 refresh 요청이 발생하지 않도록 정리했습니다.
* refresh 실패 시 accessToken, refreshToken, role 정보를 정리하고 /login으로 이동하도록 수정했습니다.
* 로그아웃 API 실패 여부와 관계없이 클라이언트 토큰이 삭제되도록 보강했습니다.
* 인증 상태와 localStorage 삭제 상태가 어긋나지 않도록 AuthContext/tokenStorage 흐름을 정리했습니다.
* 알림 API에서 401/403이 발생할 경우 IntersectionObserver가 계속 요청을 반복하지 않도록 즉시 중단 처리했습니다.
* fetchData를 useCallback으로 고정해 알림 조회 side effect가 불필요하게 반복되지 않도록 수정했습니다.

변경 파일

* NotiComponent.jsx
* AuthContext.jsx
* Logout.jsx
* MyPageMenu.jsx
* ProtectedRoute.jsx
* useAxios.js
* useCustomFetch.js
* tokenStorage.js