### PR TITLE
[FIX] 이동 경로 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import FullScreenMenu from './components/FullScreenMenu';
 
 // 아래는 각 페이지를 담당할 컴포넌트들
@@ -53,7 +53,7 @@ function App() {
 				<Route path="/ticketing/:playId" element={<TicketingPage />} />
 				<Route path="/board/*" element={<Board />} />
 				<Route path="/gallery" element={<Gallery />} />
-				<Route path="/info" element={<Info />} />
+				<Route path="/info" element={<Navigate to="/mypage/about-cc" replace />} />
 
 				<Route path="/plays" element={<Playlist />} />
 				<Route path="/plays/detail/:playId" element={<Detail />} />

--- a/src/components/FullScreenMenu.jsx
+++ b/src/components/FullScreenMenu.jsx
@@ -32,7 +32,7 @@ function FullScreenMenu({ onClose }) {
 		},
 		{
 			label: '정보',
-			path: '/info',
+			path: '/mypage/about-cc',
 		},
 		{
 			label: '마이페이지',

--- a/src/components/HomeIconMenu.jsx
+++ b/src/components/HomeIconMenu.jsx
@@ -96,7 +96,7 @@ function HomeIconMenu({ isWeb, selectedMenu }) {
 						<span>프로필</span>
 					</div>
 					{!isWeb && (
-						<div>
+						<div onClick={() => navigate('/mypage/about-cc')}>
 							<Information />
 							<span>cc</span>
 						</div>

--- a/src/components/Login/KakaoLoginButton.jsx
+++ b/src/components/Login/KakaoLoginButton.jsx
@@ -4,7 +4,11 @@ import KaKaoLogo from '@/assets/icons/KakaoRound.svg?react';
 function KakaoLoginButton() {
 	const client_id = import.meta.env.VITE_KAKAO_CLIENT_ID;
 	const redirect_uri = import.meta.env.VITE_KAKAO_REDIRECT_URI;
-	const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${client_id}&redirect_uri=${redirect_uri}&response_type=code`;
+	const kakaoAuthUrl = new URL('https://kauth.kakao.com/oauth/authorize');
+	kakaoAuthUrl.searchParams.set('client_id', client_id);
+	kakaoAuthUrl.searchParams.set('redirect_uri', redirect_uri);
+	kakaoAuthUrl.searchParams.set('response_type', 'code');
+	const KAKAO_AUTH_URL = kakaoAuthUrl.toString();
 
 	const handleKakaoLogin = () => {
 		window.location.href = KAKAO_AUTH_URL;


### PR DESCRIPTION
## Summary

CC 정보 메뉴와 모바일 하단 CC 아이콘의 이동 경로를 `/mypage/about-cc`로 정리하고, 기존 `/info` 접근도 동일 페이지로 redirect되도록 수정합니다.

## Changes

주요 변경사항:

- `/menu`의 정보 메뉴 이동 경로를 `/info`에서 `/mypage/about-cc`로 변경
- 모바일 하단 CC 아이콘 클릭 시 `/mypage/about-cc`로 이동하도록 연결
- 사용자가 직접 `/info`로 접근해도 `/mypage/about-cc`로 redirect되도록 처리
- 카카오 OAuth URL 구성에서 `through_account` 파라미터 미사용 상태 확인
- 카카오 OAuth URL 생성 방식 정리

## Scope

포함된 것:
- CC 정보 페이지 이동 경로 정리
- `/info` legacy route redirect 처리
- 모바일 하단 CC 아이콘 라우팅 수정
- 카카오 OAuth URL 생성 방식 정리
- `through_account` 파라미터 미사용 상태 확인

## Screenshots / Video

N/A - 라우팅 및 OAuth URL 구성 정리 작업으로 별도 스크린샷은 생략합니다.

## Notes

이번 PR은 CC 정보 페이지의 실제 사용 경로를 `/mypage/about-cc`로 통일하기 위한 작업입니다.

기존 `/info` 경로는 직접 접근 가능성을 고려해 제거하지 않고 `/mypage/about-cc`로 redirect되도록 유지했습니다.  
카카오 OAuth 쪽은 `through_account` 파라미터가 더 이상 사용되지 않는 상태를 확인하고 URL 생성 방식을 정리했습니다.

## Checklist

- [x] PR에서 설명한 Scope 외 변경이 섞이지 않았음
- [x] application code를 수정한 경우 빌드 확인했음
- [x] MVP scope를 벗어나는 기능을 추가하지 않았음
- [x] 실제 개인정보나 API key를 커밋하지 않았음
- [x] UI 변경이 있는 경우 screenshots/video를 첨부했거나 생략 사유를 작성했음