### PR TITLE
feat: [임시] 앱 심사용 일반 로그인 버튼/화면 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import FullScreenMenu from './components/FullScreenMenu';
 // 아래는 각 페이지를 담당할 컴포넌트들
 import Onboarding from './pages/login/Onboarding.jsx';
 import Login from './pages/login/Login.jsx';
+import GeneralLogin from './pages/login/GeneralLogin.jsx';
 import KakaoCallback from './pages/login/KakaoCallback.jsx';
 import Logout from './pages/logout/Logout';
 import Withdrawal from './pages/withdrawal/Withdrawal';
@@ -34,6 +35,7 @@ function App() {
 		<Routes>
 			<Route path="/login" element={<Onboarding />} />
 			<Route path="/login/auth" element={<Login />} />
+			<Route path="/login/general" element={<GeneralLogin />} />
 			<Route path="/auth/kakao/callback" element={<KakaoCallback />} />
 			<Route path="/logout" element={<Logout />} />
 			<Route path="/withdrawal" element={<Withdrawal />} />

--- a/src/components/Login/GeneralLoginButton.jsx
+++ b/src/components/Login/GeneralLoginButton.jsx
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+
+function GeneralLoginButton() {
+	const navigate = useNavigate();
+
+	const handleGeneralLogin = () => {
+		navigate('/login/general');
+	};
+
+	return <Button onClick={handleGeneralLogin}>일반 로그인하기</Button>;
+}
+
+export default GeneralLoginButton;
+
+const Button = styled.button`
+	padding: 10px 100px;
+
+	display: flex;
+	gap: 8px;
+	justify-content: center;
+	align-items: center;
+	background: ${({ theme }) => theme.colors.pink200};
+	border-radius: 5px;
+
+	color: ${({ theme }) => theme.colors.pink600};
+	font-size: ${({ theme }) => theme.font.fontSize.body14};
+	font-weight: ${({ theme }) => theme.font.fontWeight.regular};
+
+	@media (min-width: 768px) {
+		width: 420px;
+		height: 48px;
+
+		font-weight: ${({ theme }) => theme.font.fontWeight.extraBold};
+	}
+`;

--- a/src/pages/login/GeneralLogin.jsx
+++ b/src/pages/login/GeneralLogin.jsx
@@ -1,0 +1,136 @@
+import styled from 'styled-components';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import LogoWeb from '@/assets/icons/login/LogoWeb.svg?react';
+import LogoMobile from '@/assets/icons/login/LogoMobile.svg?react';
+import chevron from '@/assets/icons/chevronLeft.svg?react';
+import { useIsMobile } from '@/utils/hooks/useIsMobile';
+import { useAuth } from '@/context/AuthContext';
+import { axiosInstance } from '@/utils/apis/axiosInstance';
+
+// [임시] 앱 심사용 일반 로그인. 심사 통과 후 revert 대상.
+function GeneralLogin() {
+	const isMobile = useIsMobile();
+	const navigate = useNavigate();
+	const { setAuthInfo } = useAuth();
+
+	const [email, setEmail] = useState('');
+	const [password, setPassword] = useState('');
+
+	const handleLogin = async () => {
+		if (!email || !password) {
+			alert('이메일과 비밀번호를 입력해 주세요.');
+			return;
+		}
+		try {
+			const response = await axiosInstance.post('/auth/review/login', {
+				email,
+				password,
+			});
+			const { accessToken, refreshToken } = response.data;
+			setAuthInfo(accessToken, refreshToken, '/');
+		} catch (error) {
+			console.error('일반 로그인 실패:', error);
+			alert('로그인에 실패했습니다. 이메일 또는 비밀번호를 확인해 주세요.');
+		}
+	};
+
+	return (
+		<Container>
+			<Chevron onClick={() => navigate(-1)} />
+			{isMobile ? <LogoMobile /> : <LogoWeb />}
+			<Form
+				onSubmit={(e) => {
+					e.preventDefault();
+					handleLogin();
+				}}
+			>
+				<Input
+					placeholder="이메일"
+					type="email"
+					value={email}
+					onChange={(e) => setEmail(e.target.value)}
+				/>
+				<Input
+					placeholder="비밀번호"
+					type="password"
+					value={password}
+					onChange={(e) => setPassword(e.target.value)}
+				/>
+				<Button type="submit">로그인</Button>
+			</Form>
+		</Container>
+	);
+}
+
+export default GeneralLogin;
+
+const Container = styled.div`
+	min-height: 100vh;
+	display: flex;
+	flex-direction: column;
+	gap: 240px;
+	justify-content: center;
+	align-items: center;
+
+	@media (min-width: 768px) {
+		gap: 144px;
+	}
+
+	position: relative;
+`;
+
+const Chevron = styled(chevron)`
+	position: absolute;
+	top: 20px;
+	left: 28px;
+`;
+
+const Form = styled.form`
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	align-items: center;
+`;
+
+const Input = styled.input`
+	width: 280px;
+	height: 48px;
+	padding: 0 16px;
+
+	border-radius: 5px;
+	background: ${({ theme }) => theme.colors.grayWhite};
+	border: 1px solid ${({ theme }) => theme.colors.gray300};
+
+	color: ${({ theme }) => theme.colors.grayMain};
+	font-size: ${({ theme }) => theme.font.fontSize.body14};
+	font-weight: ${({ theme }) => theme.font.fontWeight.regular};
+
+	outline: none;
+
+	&::placeholder {
+		color: ${({ theme }) => theme.colors.gray400};
+	}
+
+	@media (min-width: 768px) {
+		width: 420px;
+	}
+`;
+
+const Button = styled.button`
+	width: 280px;
+	height: 48px;
+
+	border-radius: 5px;
+	background: ${({ theme }) => theme.colors.pink600};
+
+	color: ${({ theme }) => theme.colors.grayWhite};
+	font-size: ${({ theme }) => theme.font.fontSize.body14};
+	font-weight: ${({ theme }) => theme.font.fontWeight.bold};
+
+	@media (min-width: 768px) {
+		width: 420px;
+
+		font-weight: ${({ theme }) => theme.font.fontWeight.extraBold};
+	}
+`;

--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import KakaoLoginButton from '@/components/Login/KakaoLoginButton';
+import GeneralLoginButton from '@/components/Login/GeneralLoginButton';
 import LogoWeb from '@/assets/icons/login/LogoWeb.svg?react';
 import LogoMobile from '@/assets/icons/login/LogoMobile.svg?react';
 import chevron from '@/assets/icons/chevronLeft.svg?react';
@@ -23,7 +24,10 @@ function Login() {
 		<Container>
 			<Chevron onClick={() => navigate(-1)} />
 			{isMobile ? <LogoMobile /> : <LogoWeb />}
-			<KakaoLoginButton />
+			<ButtonGroup>
+				<KakaoLoginButton />
+				<GeneralLoginButton />
+			</ButtonGroup>
 		</Container>
 	);
 }
@@ -49,4 +53,11 @@ const Chevron = styled(chevron)`
 	position: absolute;
 	top: 20px;
 	left: 28px;
+`;
+
+const ButtonGroup = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	align-items: center;
 `;


### PR DESCRIPTION
- 로그인 화면(카카오 버튼 하단)에 '일반 로그인하기' 버튼 추가 (예매자/공연등록자 공통)
- /login/general 일반 로그인 화면(이메일/비밀번호) 추가, POST /auth/review/login 호출
- 기존 카카오 버튼과 디자인 일관성 유지(동일 사이즈/라운드/폰트, pink 팔레트)
- 심사 통과 후 본 커밋 revert 예정